### PR TITLE
Fixed the code so as to return the last element as well when the list…

### DIFF
--- a/Exercises/ch6-CommonCollections.asciidoc
+++ b/Exercises/ch6-CommonCollections.asciidoc
@@ -106,7 +106,7 @@ Finally, let's solve this with an old-fashioned recursive function. Limited to a
 [source,scala]
 -------------------------------------------------------------------------------
 scala> def first[A](items: List[A], count: Int): List[A] = {
-     |   if (count > 0 && items.tail != Nil) items.head :: first(items.tail, count - 1)
+     |   if (count > 0) items.head :: first(items.tail, count - 1)
      |   else Nil
      | }
 first: [A](items: List[A], count: Int)List[A]


### PR DESCRIPTION
…'s length is passed as an argument.
The last element was not returned when the size of the List was passed as `count` argument. This problem did not occur when the `count` was less than the size of the List
